### PR TITLE
Change File type in Drag module to elm/File, update examples

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,6 +14,7 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/file": "1.0.1 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0"
     },

--- a/examples/DragAndDrop/elm.json
+++ b/examples/DragAndDrop/elm.json
@@ -7,15 +7,17 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.1",
+            "elm/core": "1.0.2",
+            "elm/file": "1.0.1",
             "elm/html": "1.0.0",
-            "elm/json": "1.0.0"
+            "elm/json": "1.1.2"
         },
         "indirect": {
+            "elm/bytes": "1.0.7",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
+            "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {

--- a/examples/FileDrop/Main.elm
+++ b/examples/FileDrop/Main.elm
@@ -1,6 +1,7 @@
-module Main exposing (..)
+module Main exposing (DragEvent(..), MetaData, WithoutRawData, extractMetadata, fileDropConfig, main, view, withoutRawData)
 
 import Browser
+import File exposing (File)
 import Html exposing (Html, div, p, text)
 import Html.Events.Extra.Drag as Drag
 import Html.Events.Extra.Mouse as Mouse
@@ -63,9 +64,9 @@ withoutRawData event =
     }
 
 
-extractMetadata : Drag.File -> MetaData
+extractMetadata : File -> MetaData
 extractMetadata file =
-    { name = file.name
-    , mimeType = file.mimeType
-    , size = file.size
+    { name = File.name file
+    , mimeType = File.mime file
+    , size = File.size file
     }

--- a/examples/FileDrop/elm.json
+++ b/examples/FileDrop/elm.json
@@ -7,15 +7,17 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.1",
+            "elm/core": "1.0.2",
+            "elm/file": "1.0.1",
             "elm/html": "1.0.0",
-            "elm/json": "1.0.0"
+            "elm/json": "1.1.2"
         },
         "indirect": {
+            "elm/bytes": "1.0.7",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
+            "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {

--- a/examples/Mouse/elm.json
+++ b/examples/Mouse/elm.json
@@ -7,15 +7,17 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.1",
+            "elm/core": "1.0.2",
+            "elm/file": "1.0.1",
             "elm/html": "1.0.0",
-            "elm/json": "1.0.0"
+            "elm/json": "1.1.2"
         },
         "indirect": {
+            "elm/bytes": "1.0.7",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
+            "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {

--- a/examples/Pointer/elm.json
+++ b/examples/Pointer/elm.json
@@ -7,15 +7,17 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.1",
+            "elm/core": "1.0.2",
+            "elm/file": "1.0.1",
             "elm/html": "1.0.0",
-            "elm/json": "1.0.0"
+            "elm/json": "1.1.2"
         },
         "indirect": {
+            "elm/bytes": "1.0.7",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
+            "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {

--- a/src/Html/Events/Extra/Drag.elm
+++ b/src/Html/Events/Extra/Drag.elm
@@ -72,6 +72,7 @@ to use HTML5 drag and drop API instead of your own custom solution.
 
 -}
 
+import File exposing (File)
 import Html
 import Html.Attributes
 import Html.Events
@@ -132,31 +133,15 @@ type alias DataTransfer =
     }
 
 
-{-| A file object is a specific kind of blob.
-Its raw JavaScript value is hold in the `data` attribute
-in the form of a `Json.Decode.Value`.
-This corresponds to a JavaScript [`File`][jsFile]
+{-| This type alias used to represent file blobs in this application.
 
-  - `name`: name of the file, without the path for security reasons
-  - `mimeType`: [MIME] type of the file
-  - `size`: size of the file in bytes
+Now, however, Elm has an official File type in (elm/File)[https://package.elm-lang.org/packages/elm/file/latest/File]!
 
-_Remark: providing these properties as attributes in an elm record
-is the easiest way of bringing this `File` API to elm.
-Of course if at some point the `File` API is supported in elm,
-this would be changed to the supported version._
-
-[jsFile]: https://developer.mozilla.org/en-US/docs/Web/API/File
-[MIME]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+This alias has been rewritten to reference that type. Go see the elm/File docs for usage instructions!
 
 -}
 type alias File =
-    -- no support of lastModified in Safari
-    { name : String
-    , mimeType : String
-    , size : Int
-    , data : Decode.Value
-    }
+    File.File
 
 
 
@@ -405,12 +390,11 @@ fileListDecoder =
 
 
 {-| `File` decoder.
-It is provided in case you would like to reuse/extend it.
+
+With the File alias now referring to elm/File's official file type,
+this function is now just a compatibility reference to File.decoder.
+
 -}
 fileDecoder : Decoder File
 fileDecoder =
-    Decode.map4 File
-        (Decode.field "name" Decode.string)
-        (Decode.field "type" Decode.string)
-        (Decode.field "size" Decode.int)
-        Decode.value
+    File.decoder


### PR DESCRIPTION
Fixes #17.

My first instinct was to remove Drag.File entirely, but that resulted in two major interface changes rather than one. Decided instead to have Drag.File alias elm/File, for all the type compatibility with only one major interface change.

I have not yet done the version bump, nor changed the changelog.

All of the examples I could test appear to work as before. Let me know if this PR needs anything else!
