### PR TITLE
fix Mouse.eventDecoder example

### DIFF
--- a/src/Html/Events/Extra/Mouse.elm
+++ b/src/Html/Events/Extra/Mouse.elm
@@ -337,7 +337,7 @@ And use it like follows:
 
             options message =
                 { message = message
-                , stopPropagation = True
+                , stopPropagation = False
                 , preventDefault = True
                 }
         in

--- a/src/Html/Events/Extra/Mouse.elm
+++ b/src/Html/Events/Extra/Mouse.elm
@@ -336,7 +336,7 @@ And use it like follows:
                 , preventDefault = True
                 }
             decoder =
-                decodeWeelWithMovement
+                decodeWithMovement
                     |> Decode.map tag
                     |> Decode.map options
         in

--- a/src/Html/Events/Extra/Mouse.elm
+++ b/src/Html/Events/Extra/Mouse.elm
@@ -330,11 +330,17 @@ And use it like follows:
     onMove : (EventWithMovement -> msg) -> Html.Attribute msg
     onMove tag =
         let
-            options =
-                { stopPropagation = True, preventDefault = True }
+            options message =
+                { message = message
+                , stopPropagation = True
+                , preventDefault = True
+                }
+            decoder =
+                decodeWeelWithMovement
+                    |> Decode.map tag
+                    |> Decode.map options
         in
-        Decode.map tag decodeWithMovement
-            |> Html.Events.onWithOptions "mousemove" options
+        Html.Events.custom "mousemove" decoder
 
 -}
 eventDecoder : Decoder Event

--- a/src/Html/Events/Extra/Mouse.elm
+++ b/src/Html/Events/Extra/Mouse.elm
@@ -330,15 +330,16 @@ And use it like follows:
     onMove : (EventWithMovement -> msg) -> Html.Attribute msg
     onMove tag =
         let
+            decoder =
+                decodeWithMovement
+                    |> Decode.map tag
+                    |> Decode.map options
+
             options message =
                 { message = message
                 , stopPropagation = True
                 , preventDefault = True
                 }
-            decoder =
-                decodeWithMovement
-                    |> Decode.map tag
-                    |> Decode.map options
         in
         Html.Events.custom "mousemove" decoder
 


### PR DESCRIPTION
`Html.Events.onWithOptions` was replaced with `Html.Events.custom` in 0.19