### PR TITLE
Fix mouse event documentation link

### DIFF
--- a/src/Html/Events/Extra/Pointer.elm
+++ b/src/Html/Events/Extra/Pointer.elm
@@ -54,7 +54,7 @@ And to know if the shift key was pressed:
 
 [PointerEvent]: https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent
 [MouseEvent]: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent
-[Mouse-Event]: http://package.elm-lang.org/packages/mpizenberg/elm-mouse-events/latest/Mouse#Event
+[Mouse-Event]: Html-Events-Extra-Mouse#Event
 
 -}
 type alias Event =


### PR DESCRIPTION
This link was still pointing to the event within the old package, `elm-mouse-events`.

Unfortunately, I can't see how to test this change, but I think a relative link is better than another absolute one.